### PR TITLE
Change obsolete cop rule

### DIFF
--- a/linter-configs/.rubocop.yml
+++ b/linter-configs/.rubocop.yml
@@ -42,7 +42,7 @@ Style/EmptyLinesAroundClassBody:
   Enabled: false
   EnforcedStyle: empty_lines
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 Metrics/LineLength:

--- a/linter-configs/.rubocop.yml
+++ b/linter-configs/.rubocop.yml
@@ -42,8 +42,5 @@ Style/EmptyLinesAroundClassBody:
   Enabled: false
   EnforcedStyle: empty_lines
 
-Style/SpaceBeforeFirstArg:
-  Enabled: false
-
 Metrics/LineLength:
   Max: 100


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes-12
`Style/SingleSpaceBeforeFirstArg` cop has been renamed to `Style/SpaceBeforeFirstArg`, which more accurately reflects what it now does.
