### PR TITLE
Change obsolete RunRailsCops config param

### DIFF
--- a/linter-configs/.rubocop.yml
+++ b/linter-configs/.rubocop.yml
@@ -1,5 +1,5 @@
-AllCops:
-  RunRailsCops: true
+Rails:
+  Enabled: true
 
 Style/IndentationWidth:
   Width: 2


### PR DESCRIPTION
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes-12
The `RunRailsCops` config parameter in .rubocop.yml is now obsolete
