### PR TITLE
Converted JSCS config to ESLint

### DIFF
--- a/linter-configs/.eslintrc.json
+++ b/linter-configs/.eslintrc.json
@@ -1,4 +1,13 @@
 {
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
+  "extends": "eslint:recommended",
+  "env": {
+    "browser": true
+  },  
   "rules": {
     "space-before-function-paren": [2, "always"],
     "no-empty": [2, { "allowEmptyCatch": true }],

--- a/linter-configs/.eslintrc.json
+++ b/linter-configs/.eslintrc.json
@@ -1,0 +1,66 @@
+{
+  "rules": {
+    "space-before-function-paren": [2, "always"],
+    "no-empty": [2, { "allowEmptyCatch": true }],
+    "no-spaced-func": 2,
+    "array-bracket-spacing": [2, "always"],
+    "space-in-parens": [2, "never"],
+    "quote-props": [2, "as-needed"],
+    "key-spacing": [
+      2,
+      {
+        "beforeColon": false,
+        "afterColon": true
+      }
+    ],
+    "space-unary-ops": [
+      2,
+      {
+        "words": false,
+        "nonwords": false
+      }
+    ],
+    "no-mixed-spaces-and-tabs": 2,
+    "no-trailing-spaces": 2,
+    "comma-dangle": [2, "never"],
+    "comma-spacing": [
+      2,
+      {
+        "after": true,
+        "before": false
+      }
+    ],
+    "yoda": [2, "never"],
+    "no-with": 2,
+    "brace-style": [
+      2,
+      "1tbs",
+      { "allowSingleLine": true }
+    ],
+    "no-multiple-empty-lines": 2,
+    "no-multi-str": 2,
+    "one-var": [2, "never"],
+    "semi-spacing": [
+      2,
+      {
+        "before": false,
+        "after": true
+      }
+     ],
+    "space-before-blocks": [2, "always"],
+    "wrap-iife": 2,
+    "comma-style": [2, "last"],
+    "space-infix-ops": 2,
+    "camelcase": [2, { "properties": "never" }],
+    "eol-last": 2,
+    "dot-notation": 2,
+    "curly": [2, "all"],
+    "keyword-spacing": [2, {}],
+    "lines-around-comment": [2, { "beforeLineComment": true }],
+    "semi": [2, "always"],
+    "consistent-this": [2, "_this"],
+    "linebreak-style": [2, "unix"],
+    "quotes": [2, "single", { "avoidEscape": true }],
+    "indent": [2, 2, { "SwitchCase": 1 }]
+  }
+}


### PR DESCRIPTION
Converted `.jscsrc` to `.eslintrc.json`. JSCS merged with ESLint:
https://medium.com/@markelog/jscs-end-of-the-line-bc9bf0b3fdb2

It may be a good idea to start using ESLint instead of JSCS
